### PR TITLE
Refactor `Optional`

### DIFF
--- a/lib/src/main/java/co/raccoons/java/util/Optional.java
+++ b/lib/src/main/java/co/raccoons/java/util/Optional.java
@@ -358,9 +358,9 @@ public class Optional<T> {
      * @apiNote This method can be used to transform a {@code Stream} of optional
      * elements to a {@code Stream} of present value elements:
      * <pre>{@code
-     *                                                     Stream<Optional<T>> os = ..
-     *                                                     Stream<T> s = os.flatMap(Optional::stream)
-     *                                                 }</pre>
+     *     Stream<Optional<T>> os = ..
+     *     Stream<T> s = os.flatMap(Optional::stream)
+     * }</pre>
      * @since 9
      */
     public Stream<T> stream() {

--- a/lib/src/main/java/co/raccoons/java/util/Optional.java
+++ b/lib/src/main/java/co/raccoons/java/util/Optional.java
@@ -50,55 +50,120 @@ import java.util.stream.Stream;
  * use instances for synchronization, or unpredictable behavior may
  * occur. For example, in a future release, synchronization may fail.
  *
- * @apiNote
- * {@code Optional} is primarily intended for use as a method return type where
+ * @param <T> the type of value
+ * @apiNote {@code Optional} is primarily intended for use as a method return type where
  * there is a clear need to represent "no result," and where using {@code null}
  * is likely to cause errors. A variable whose type is {@code Optional} should
  * never itself be {@code null}; it should always point to an {@code Optional}
  * instance.
- *
- * @param <T> the type of value
  * @since 1.8
  */
-public final class Optional<T> {
-    /**
-     * Common instance for {@code empty()}.
-     */
-    private static final Optional<?> EMPTY = new Optional<>(null);
-
+public class Optional<T> {
     /**
      * If non-null, the value; if null, indicates no value is present
      */
     private final T value;
 
     /**
-     * Returns an empty {@code Optional} instance.  No value is present for this
-     * {@code Optional}.
-     *
-     * @apiNote
-     * Though it may be tempting to do so, avoid testing if an object is empty
-     * by comparing with {@code ==} or {@code !=} against instances returned by
-     * {@code Optional.empty()}.  There is no guarantee that it is a singleton.
-     * Instead, use {@link #isEmpty()} or {@link #isPresent()}.
-     *
-     * @param <T> The type of the non-existent value
-     * @return an empty {@code Optional}
-     */
-    public static<T> Optional<T> empty() {
-        @SuppressWarnings("unchecked")
-        Optional<T> t = (Optional<T>) EMPTY;
-        return t;
-    }
-
-    /**
      * Constructs an instance with the described value.
      *
      * @param value the value to describe; it's the caller's responsibility to
-     *        ensure the value is non-{@code null} unless creating the singleton
-     *        instance returned by {@code empty()}.
+     *              ensure the value is non-{@code null} unless creating the singleton
+     *              instance returned by {@code empty()}.
      */
     private Optional(T value) {
         this.value = value;
+    }
+
+    /**
+     * Returns an empty {@code Optional} instance.  No value is present for this
+     * {@code Optional}.
+     *
+     * @param <T> The type of the non-existent value
+     * @return an empty {@code Optional}
+     * @apiNote Though it may be tempting to do so, avoid testing if an object is empty
+     * by comparing with {@code ==} or {@code !=} against instances returned by
+     * {@code Optional.empty()}.  There is no guarantee that it is a singleton.
+     * Instead, use {@link #isEmpty()} or {@link #isPresent()}.
+     */
+    public static <T> Optional<T> empty() {
+        return new Optional<>(null) {
+
+            @Override
+            public T get() {
+                throw new NoSuchElementException("No value present");
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return true;
+            }
+
+            @Override
+            public boolean isPresent() {
+                return false;
+            }
+
+            @Override
+            public void ifPresent(Consumer<? super T> action) {
+                // Intentionally empty
+            }
+
+            @Override
+            public void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction) {
+                Objects.requireNonNull(emptyAction);
+                emptyAction.run();
+            }
+
+            @Override
+            public Optional<T> filter(Predicate<? super T> predicate) {
+                return this;
+            }
+
+            @Override
+            public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+                return empty();
+            }
+
+            @Override
+            public <U> Optional<U> flatMap(Function<? super T, ? extends Optional<? extends U>> mapper) {
+                return empty();
+            }
+
+            @Override
+            public Optional<T> or(Supplier<? extends Optional<? extends T>> supplier) {
+                Objects.requireNonNull(supplier);
+                @SuppressWarnings("unchecked")
+                Optional<T> r = (Optional<T>) supplier.get();
+                return Objects.requireNonNull(r);
+            }
+
+            @Override
+            public Stream<T> stream() {
+                return Stream.empty();
+            }
+
+            @Override
+            public T orElse(T other) {
+                return other;
+            }
+
+            @Override
+            public T orElseGet(Supplier<? extends T> supplier) {
+                Objects.requireNonNull(supplier);
+                return supplier.get();
+            }
+
+            @Override
+            public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+                throw exceptionSupplier.get();
+            }
+
+            @Override
+            public String toString() {
+                return "Optional.empty";
+            }
+        };
     }
 
     /**
@@ -106,7 +171,7 @@ public final class Optional<T> {
      * value.
      *
      * @param value the value to describe, which must be non-{@code null}
-     * @param <T> the type of the value
+     * @param <T>   the type of the value
      * @return an {@code Optional} with the value present
      * @throws NullPointerException if value is {@code null}
      */
@@ -119,30 +184,25 @@ public final class Optional<T> {
      * non-{@code null}, otherwise returns an empty {@code Optional}.
      *
      * @param value the possibly-{@code null} value to describe
-     * @param <T> the type of the value
+     * @param <T>   the type of the value
      * @return an {@code Optional} with a present value if the specified value
-     *         is non-{@code null}, otherwise an empty {@code Optional}
+     * is non-{@code null}, otherwise an empty {@code Optional}
      */
     @SuppressWarnings("unchecked")
     public static <T> Optional<T> ofNullable(T value) {
-        return value == null ? (Optional<T>) EMPTY
-                             : new Optional<>(value);
+        return value == null ? empty()
+                : new Optional<>(value);
     }
 
     /**
      * If a value is present, returns the value, otherwise throws
      * {@code NoSuchElementException}.
      *
-     * @apiNote
-     * The preferred alternative to this method is {@link #orElseThrow()}.
-     *
      * @return the non-{@code null} value described by this {@code Optional}
      * @throws NoSuchElementException if no value is present
+     * @apiNote The preferred alternative to this method is {@link #orElseThrow()}.
      */
     public T get() {
-        if (value == null) {
-            throw new NoSuchElementException("No value present");
-        }
         return value;
     }
 
@@ -152,18 +212,18 @@ public final class Optional<T> {
      * @return {@code true} if a value is present, otherwise {@code false}
      */
     public boolean isPresent() {
-        return value != null;
+        return true;
     }
 
     /**
      * If a value is  not present, returns {@code true}, otherwise
      * {@code false}.
      *
-     * @return  {@code true} if a value is not present, otherwise {@code false}
-     * @since   11
+     * @return {@code true} if a value is not present, otherwise {@code false}
+     * @since 11
      */
     public boolean isEmpty() {
-        return value == null;
+        return false;
     }
 
     /**
@@ -172,32 +232,27 @@ public final class Optional<T> {
      *
      * @param action the action to be performed, if a value is present
      * @throws NullPointerException if value is present and the given action is
-     *         {@code null}
+     *                              {@code null}
      */
     public void ifPresent(Consumer<? super T> action) {
-        if (value != null) {
-            action.accept(value);
-        }
+        Objects.requireNonNull(action);
+        action.accept(value);
     }
 
     /**
      * If a value is present, performs the given action with the value,
      * otherwise performs the given empty-based action.
      *
-     * @param action the action to be performed, if a value is present
+     * @param action      the action to be performed, if a value is present
      * @param emptyAction the empty-based action to be performed, if no value is
-     *        present
+     *                    present
      * @throws NullPointerException if a value is present and the given action
-     *         is {@code null}, or no value is present and the given empty-based
-     *         action is {@code null}.
+     *                              is {@code null}, or no value is present and the given empty-based
+     *                              action is {@code null}.
      * @since 9
      */
     public void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction) {
-        if (value != null) {
-            action.accept(value);
-        } else {
-            emptyAction.run();
-        }
+        ifPresent(action);
     }
 
     /**
@@ -207,17 +262,13 @@ public final class Optional<T> {
      *
      * @param predicate the predicate to apply to a value, if present
      * @return an {@code Optional} describing the value of this
-     *         {@code Optional}, if a value is present and the value matches the
-     *         given predicate, otherwise an empty {@code Optional}
+     * {@code Optional}, if a value is present and the value matches the
+     * given predicate, otherwise an empty {@code Optional}
      * @throws NullPointerException if the predicate is {@code null}
      */
     public Optional<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate);
-        if (isEmpty()) {
-            return this;
-        } else {
-            return predicate.test(value) ? this : empty();
-        }
+        return predicate.test(value) ? this : empty();
     }
 
     /**
@@ -228,8 +279,13 @@ public final class Optional<T> {
      * <p>If the mapping function returns a {@code null} result then this method
      * returns an empty {@code Optional}.
      *
-     * @apiNote
-     * This method supports post-processing on {@code Optional} values, without
+     * @param mapper the mapping function to apply to a value, if present
+     * @param <U>    The type of the value returned from the mapping function
+     * @return an {@code Optional} describing the result of applying a mapping
+     * function to the value of this {@code Optional}, if a value is
+     * present, otherwise an empty {@code Optional}
+     * @throws NullPointerException if the mapping function is {@code null}
+     * @apiNote This method supports post-processing on {@code Optional} values, without
      * the need to explicitly check for a return status.  For example, the
      * following code traverses a stream of URIs, selects one that has not
      * yet been processed, and creates a path from that URI, returning
@@ -238,28 +294,17 @@ public final class Optional<T> {
      * <pre>{@code
      *     Optional<Path> p =
      *         uris.stream().filter(uri -> !isProcessedYet(uri))
-     *                       .findFirst()
-     *                       .map(Paths::get);
+     *             .findFirst()
+     *             .map(Paths::get);
      * }</pre>
-     *
+     * <p>
      * Here, {@code findFirst} returns an {@code Optional<URI>}, and then
      * {@code map} returns an {@code Optional<Path>} for the desired
      * URI if one exists.
-     *
-     * @param mapper the mapping function to apply to a value, if present
-     * @param <U> The type of the value returned from the mapping function
-     * @return an {@code Optional} describing the result of applying a mapping
-     *         function to the value of this {@code Optional}, if a value is
-     *         present, otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is {@code null}
      */
     public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper);
-        if (isEmpty()) {
-            return empty();
-        } else {
-            return Optional.ofNullable(mapper.apply(value));
-        }
+        return Optional.ofNullable(mapper.apply(value));
     }
 
     /**
@@ -272,24 +317,20 @@ public final class Optional<T> {
      * invoked, {@code flatMap} does not wrap it within an additional
      * {@code Optional}.
      *
-     * @param <U> The type of value of the {@code Optional} returned by the
-     *            mapping function
+     * @param <U>    The type of value of the {@code Optional} returned by the
+     *               mapping function
      * @param mapper the mapping function to apply to a value, if present
      * @return the result of applying an {@code Optional}-bearing mapping
-     *         function to the value of this {@code Optional}, if a value is
-     *         present, otherwise an empty {@code Optional}
+     * function to the value of this {@code Optional}, if a value is
+     * present, otherwise an empty {@code Optional}
      * @throws NullPointerException if the mapping function is {@code null} or
-     *         returns a {@code null} result
+     *                              returns a {@code null} result
      */
     public <U> Optional<U> flatMap(Function<? super T, ? extends Optional<? extends U>> mapper) {
         Objects.requireNonNull(mapper);
-        if (isEmpty()) {
-            return empty();
-        } else {
-            @SuppressWarnings("unchecked")
-            Optional<U> r = (Optional<U>) mapper.apply(value);
-            return Objects.requireNonNull(r);
-        }
+        @SuppressWarnings("unchecked")
+        Optional<U> r = (Optional<U>) mapper.apply(value);
+        return Objects.requireNonNull(r);
     }
 
     /**
@@ -297,46 +338,33 @@ public final class Optional<T> {
      * otherwise returns an {@code Optional} produced by the supplying function.
      *
      * @param supplier the supplying function that produces an {@code Optional}
-     *        to be returned
+     *                 to be returned
      * @return returns an {@code Optional} describing the value of this
-     *         {@code Optional}, if a value is present, otherwise an
-     *         {@code Optional} produced by the supplying function.
+     * {@code Optional}, if a value is present, otherwise an
+     * {@code Optional} produced by the supplying function.
      * @throws NullPointerException if the supplying function is {@code null} or
-     *         produces a {@code null} result
+     *                              produces a {@code null} result
      * @since 9
      */
     public Optional<T> or(Supplier<? extends Optional<? extends T>> supplier) {
-        Objects.requireNonNull(supplier);
-        if (isPresent()) {
-            return this;
-        } else {
-            @SuppressWarnings("unchecked")
-            Optional<T> r = (Optional<T>) supplier.get();
-            return Objects.requireNonNull(r);
-        }
+        return this;
     }
 
     /**
      * If a value is present, returns a sequential {@link Stream} containing
      * only that value, otherwise returns an empty {@code Stream}.
      *
-     * @apiNote
-     * This method can be used to transform a {@code Stream} of optional
+     * @return the optional value as a {@code Stream}
+     * @apiNote This method can be used to transform a {@code Stream} of optional
      * elements to a {@code Stream} of present value elements:
      * <pre>{@code
-     *     Stream<Optional<T>> os = ..
-     *     Stream<T> s = os.flatMap(Optional::stream)
-     * }</pre>
-     *
-     * @return the optional value as a {@code Stream}
+     *                                                     Stream<Optional<T>> os = ..
+     *                                                     Stream<T> s = os.flatMap(Optional::stream)
+     *                                                 }</pre>
      * @since 9
      */
     public Stream<T> stream() {
-        if (isEmpty()) {
-            return Stream.empty();
-        } else {
-            return Stream.of(value);
-        }
+        return Stream.of(value);
     }
 
     /**
@@ -344,11 +372,11 @@ public final class Optional<T> {
      * {@code other}.
      *
      * @param other the value to be returned, if no value is present.
-     *        May be {@code null}.
+     *              May be {@code null}.
      * @return the value, if present, otherwise {@code other}
      */
     public T orElse(T other) {
-        return value != null ? value : other;
+        return get();
     }
 
     /**
@@ -357,12 +385,12 @@ public final class Optional<T> {
      *
      * @param supplier the supplying function that produces a value to be returned
      * @return the value, if present, otherwise the result produced by the
-     *         supplying function
+     * supplying function
      * @throws NullPointerException if no value is present and the supplying
-     *         function is {@code null}
+     *                              function is {@code null}
      */
     public T orElseGet(Supplier<? extends T> supplier) {
-        return value != null ? value : supplier.get();
+        return get();
     }
 
     /**
@@ -374,35 +402,26 @@ public final class Optional<T> {
      * @since 10
      */
     public T orElseThrow() {
-        if (value == null) {
-            throw new NoSuchElementException("No value present");
-        }
-        return value;
+        return get();
     }
 
     /**
      * If a value is present, returns the value, otherwise throws an exception
      * produced by the exception supplying function.
      *
-     * @apiNote
-     * A method reference to the exception constructor with an empty argument
+     * @param <X>               Type of the exception to be thrown
+     * @param exceptionSupplier the supplying function that produces an
+     *                          exception to be thrown
+     * @return the value, if present
+     * @throws X                    if no value is present
+     * @throws NullPointerException if no value is present and the exception
+     *                              supplying function is {@code null}
+     * @apiNote A method reference to the exception constructor with an empty argument
      * list can be used as the supplier. For example,
      * {@code IllegalStateException::new}
-     *
-     * @param <X> Type of the exception to be thrown
-     * @param exceptionSupplier the supplying function that produces an
-     *        exception to be thrown
-     * @return the value, if present
-     * @throws X if no value is present
-     * @throws NullPointerException if no value is present and the exception
-     *          supplying function is {@code null}
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
-        if (value != null) {
-            return value;
-        } else {
-            throw exceptionSupplier.get();
-        }
+        return get();
     }
 
     /**
@@ -416,7 +435,7 @@ public final class Optional<T> {
      *
      * @param obj an object to be tested for equality
      * @return {@code true} if the other object is "equal to" this object
-     *         otherwise {@code false}
+     * otherwise {@code false}
      */
     @Override
     public boolean equals(Object obj) {
@@ -433,7 +452,7 @@ public final class Optional<T> {
      * (zero) if no value is present.
      *
      * @return hash code value of the present value or {@code 0} if no value is
-     *         present
+     * present
      */
     @Override
     public int hashCode() {
@@ -445,17 +464,13 @@ public final class Optional<T> {
      * suitable for debugging.  The exact presentation format is unspecified and
      * may vary between implementations and versions.
      *
-     * @implSpec
-     * If a value is present the result must include its string representation
+     * @return the string representation of this instance
+     * @implSpec If a value is present the result must include its string representation
      * in the result.  Empty and present {@code Optional}s must be unambiguously
      * differentiable.
-     *
-     * @return the string representation of this instance
      */
     @Override
     public String toString() {
-        return value != null
-            ? ("Optional[" + value + "]")
-            : "Optional.empty";
+        return "Optional[" + value + "]";
     }
 }

--- a/lib/src/test/java/co/raccoons/java/util/Optional/Basic.java
+++ b/lib/src/test/java/co/raccoons/java/util/Optional/Basic.java
@@ -47,7 +47,6 @@ public class Basic {
      */
     void checkEmpty(Optional<String> empty) {
         assertTrue(empty.equals(Optional.empty()));
-        assertTrue(empty.equals(Optional.empty()));
         assertTrue(Optional.empty().equals(empty));
         assertFalse(empty.equals(Optional.of("unexpected")));
         assertFalse(Optional.of("unexpected").equals(empty));

--- a/lib/src/test/java/co/raccoons/java/util/Optional/Basic.java
+++ b/lib/src/test/java/co/raccoons/java/util/Optional/Basic.java
@@ -47,6 +47,7 @@ public class Basic {
      */
     void checkEmpty(Optional<String> empty) {
         assertTrue(empty.equals(Optional.empty()));
+        assertTrue(empty.equals(Optional.empty()));
         assertTrue(Optional.empty().equals(empty));
         assertFalse(empty.equals(Optional.of("unexpected")));
         assertFalse(Optional.of("unexpected").equals(empty));
@@ -72,6 +73,7 @@ public class Basic {
         assertFalse(b1.get());
         assertTrue(b2.get());
 
+        assertTrue(empty.equals(empty));
         assertEquals(empty.toString(), "Optional.empty");
     }
 
@@ -108,6 +110,7 @@ public class Basic {
         assertTrue(b1.get());
         assertFalse(b2.get());
 
+        assertTrue(opt.equals(opt));
         assertEquals(opt.toString(), "Optional[" + expected + "]");
     }
 


### PR DESCRIPTION
This PR refactors `Optional`.

Eliminates:
- static variable `EMPTY`;
- `if`-statements to check value for `null` in each method;
- code duplication;

Adds:
- checks in tests for equality of self reference because it were covered due to side effect of static variable `EMPTY`.
- check method parameter for `null` to avoid `NPE` of calling methods on null-objects.  